### PR TITLE
Fix misleading comment in tactics2, add and_map exercise

### DIFF
--- a/.solutions/10_tactics/tactics2.lean
+++ b/.solutions/10_tactics/tactics2.lean
@@ -11,3 +11,9 @@ theorem and_swap (P Q : Prop) (h : P ∧ Q) : Q ∧ P := by
   constructor
   · exact h.right
   · exact h.left
+
+theorem and_map (P Q R : Prop) (h : P ∧ Q) (f : Q → R) : P ∧ R := by
+  constructor
+  · exact h.left
+  · apply f
+    exact h.right

--- a/exercises/10_tactics/tactics2.lean
+++ b/exercises/10_tactics/tactics2.lean
@@ -20,6 +20,10 @@ theorem and_intro (P Q : Prop) (hp : P) (hq : Q) : P ∧ Q := by
 -- For the next theorem, you can access parts of `h : P ∧ Q`
 -- using `h.left` (or `h.1`) and `h.right` (or `h.2`).
 
--- Combine constructor and apply
+-- Use constructor and the .left/.right accessors together
 theorem and_swap (P Q : Prop) (h : P ∧ Q) : Q ∧ P := by
+  sorry
+
+-- Combine constructor and apply
+theorem and_map (P Q R : Prop) (h : P ∧ Q) (f : Q → R) : P ∧ R := by
   sorry


### PR DESCRIPTION
## Summary
- Fix the misleading "Combine constructor and apply" comment on `and_swap` (which doesn't need `apply`) — now reads "Use constructor and the .left/.right accessors together"
- Add a new `and_map` exercise that genuinely requires both `constructor` and `apply`

Closes #1

## Test plan
- [x] Exercise file builds (only `sorry` warnings)
- [x] Solution file builds cleanly