### PR TITLE
fix: Missing BEq instance for Except

### DIFF
--- a/exercises/14_do_notation/do2.lean
+++ b/exercises/14_do_notation/do2.lean
@@ -22,6 +22,7 @@ def validate (n : Int) : Except String Int := do
   sorry
 
 -- Don't change below this line!
+deriving instance BEq for Except
 #guard validate 50 == .ok 50
 #guard validate (-1) == .error "must be positive"
 #guard validate 200 == .error "must be less than 100"


### PR DESCRIPTION
Not sure if this is the right approach, or if so whether it makes sense for the `BEq` instance to live in this file, but without it I was seeing errors (aside from the `warning` about incomplete exercise) on clean checkout of `0f0e4c8`
```sh
❯ lean ./exercises/14_do_notation/do2.lean
./exercises/14_do_notation/do2.lean:21:4: warning: declaration uses `sorry`
./exercises/14_do_notation/do2.lean:25:7: error(lean.synthInstanceFailed): failed to synthesize instance of type class
  BEq (Except String Int)

Hint: Type class instance resolution failures can be inspected with the `set_option trace.Meta.synthInstance true` command.
./exercises/14_do_notation/do2.lean:25:0: error: cannot evaluate code because 'sorryAx' uses 'sorry' and/or contains errors
./exercises/14_do_notation/do2.lean:26:7: error(lean.synthInstanceFailed): failed to synthesize instance of type class
  BEq (Except String Int)

Hint: Type class instance resolution failures can be inspected with the `set_option trace.Meta.synthInstance true` command.
./exercises/14_do_notation/do2.lean:26:0: error: cannot evaluate code because 'sorryAx' uses 'sorry' and/or contains errors
./exercises/14_do_notation/do2.lean:27:7: error(lean.synthInstanceFailed): failed to synthesize instance of type class
  BEq (Except String Int)

Hint: Type class instance resolution failures can be inspected with the `set_option trace.Meta.synthInstance true` command.
./exercises/14_do_notation/do2.lean:27:0: error: cannot evaluate code because 'sorryAx' uses 'sorry' and/or contains errors
```